### PR TITLE
Increase choice of speeds to match that of modern USB Serial FTDI chips.

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb.ui/src/org/eclipse/cdt/dsf/gdb/internal/ui/launching/SerialPortSettingsBlock.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb.ui/src/org/eclipse/cdt/dsf/gdb/internal/ui/launching/SerialPortSettingsBlock.java
@@ -43,7 +43,12 @@ public class SerialPortSettingsBlock extends Observable {
 
 	private ComboDialogField fSpeedField;
 
-	private String fSpeedChoices[] = { "9600", "19200", "38400", "57600", "115200" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+	private String fSpeedChoices[] = { 
+		"9600", "19200", "38400", "57600", "115200", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+		"230400", "460800", "921600", "1000000", "1152000", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+		"1500000", "2000000", "2500000", "3000000", "3500000", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+		"4000000" //$NON-NLS-1$
+	};
 
 	private Control fControl;
 


### PR DESCRIPTION
Our Eclipse CDT distribution has had to clone SerialPortSettingsBlock  to allow serial speeds > 115200 to be set.  Under WIndows we can debug eCos on the Raspberry PI using speeds of 2Mbit/s and with a patch to gdb for Linux (hard-coded maximum of 460800) can go even higher on hi-end PCs. Doubtless other RTOS' will catch up soon - ARM Mbed has already reports of reliable serial speeds of 460800, with 921600 the next target. SerialPortSettingsBlock needs to catch up, possibly also switching to "/dev/ttyUSB0" as the default (native RS232 are a rarity nowadays).